### PR TITLE
Refactor device and dtype handling in HeartMuLaModelManager and HeartCodec to support MPS

### DIFF
--- a/util/heartlib/heartcodec/models/transformer.py
+++ b/util/heartlib/heartcodec/models/transformer.py
@@ -423,7 +423,7 @@ class PixArtAlphaCombinedFlowEmbeddings(nn.Module):
             -math.log(max_period)
             * torch.arange(start=0, end=half, device=timesteps.device)
             / half
-        ).type(timesteps.type())
+        ).to(dtype=timesteps.dtype)
         args = timesteps[:, None] * freqs[None] * scale
         embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
         if self.flow_t_size % 2:


### PR DESCRIPTION
This pull request introduces several improvements to device management, dtype handling, and code robustness for multi-device (CUDA, MPS, CPU) support in the HeartMuLa codebase. The changes ensure that the correct device and data type are selected automatically, improve memory management, and enhance compatibility with both CUDA and Apple MPS backends. The most important changes are grouped below:

**Device and dtype management improvements:**

* Added `_get_device()` and `_get_dtype()` utility functions in `__init__.py` to automatically select the best available device (CUDA > MPS > CPU) and appropriate dtype, addressing MPS bfloat16 limitations. The `HeartMuLaModelManager` now uses these utilities for device and dtype selection. [[1]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR1-R15) [[2]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR39-R57)
* The model loading and pipeline creation logic now prints device and dtype information, and uses the correct dtype for each device, improving transparency and preventing dtype mismatches. [[1]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR69-L56) [[2]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR92-R101)

**Memory and resource management:**

* Replaced direct `torch.cuda.empty_cache()` calls with device-aware cache management methods, and added device synchronization for both CUDA and MPS in `music_generation.py`. This ensures proper resource cleanup regardless of backend. [[1]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2R160-R190) [[2]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2L177-R205) [[3]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2L187-R215)
* Added device-aware random seed initialization and cache clearing in generation and transcription methods to ensure reproducibility and efficient memory usage across devices. [[1]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR143) [[2]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR173) [[3]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR256)

**Autocast and inference context:**

* Introduced `_get_autocast_context()` in `music_generation.py` to select the correct context manager (`torch.autocast` for CUDA, `torch.inference_mode` for MPS/CPU) for mixed-precision inference, improving compatibility and preventing dtype errors. [[1]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2R116-R132) [[2]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2L133-R148)

**General code cleanup and robustness:**

* Improved imports and refactored code for clarity and maintainability in both `__init__.py` and `music_generation.py`. [[1]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR1-R15) [[2]](diffhunk://#diff-ae47d5618811547b5c20b8a2e5643a75ff3137e4d775c98bc938b1d2d7a9b2b2L1-R18)
* Updated `HeartCodec.detokenize` to infer device from model parameters if not specified, increasing robustness when running on different hardware. [[1]](diffhunk://#diff-7482a1e73896dc4db9fb1eff9d482bb082b12edef939702b4e08d7b21289ea50R1-L7) [[2]](diffhunk://#diff-7482a1e73896dc4db9fb1eff9d482bb082b12edef939702b4e08d7b21289ea50L65-R75)
* Fixed a dtype conversion in `timestep_embedding` to use `.to(dtype=...)` for better compatibility.