### PR TITLE
fix: Add jax/jaxlib to requirements (einx dependency)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,7 @@ omegaconf
 bitsandbytes
 torch
 torchcodec
+
+# Required by einx (dependency of vector_quantize_pytorch) - registers jax backend on import
+jax
+jaxlib


### PR DESCRIPTION
## Problem

The `einx` library (dependency of `vector_quantize_pytorch`) tries to register a JAX backend during import, even when using PyTorch only. This causes:

```
ModuleNotFoundError: No module named 'jax.numpy'; 'jax' is not a package
```

## Solution

Add `jax` and `jaxlib` as explicit dependencies in `requirements.txt`.

## Tested On

- Windows ComfyUI installations
- Linux (Ubuntu 22.04)

## Changes

```diff
+ # Required by einx (dependency of vector_quantize_pytorch)
+ jax
+ jaxlib
```