### PR TITLE
feat: add MiniMax music cover node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,11 @@ import numpy as np
 import torch
 import torchaudio
 
+if __package__:
+    from .minimax_music_cover import MiniMax_MusicCover
+else:
+    from minimax_music_cover import MiniMax_MusicCover
+
 # ----------------------------
 # Add Local HeartLib to Path
 # ----------------------------
@@ -244,11 +249,13 @@ class HeartMuLa_Transcribe:
 NODE_CLASS_MAPPINGS = {
     "HeartMuLa_Generate": HeartMuLa_Generate,
     "HeartMuLa_Transcribe": HeartMuLa_Transcribe,
+    "MiniMax_MusicCover": MiniMax_MusicCover,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "HeartMuLa_Generate": "HeartMuLa Music Generator",
     "HeartMuLa_Transcribe": "HeartMuLa Lyrics Transcriber",
+    "MiniMax_MusicCover": "MiniMax Music Cover",
 }
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/minimax_music_cover.py
+++ b/minimax_music_cover.py
@@ -1,0 +1,173 @@
+import json
+import os
+import urllib.error
+import urllib.request
+import uuid
+
+
+MINIMAX_MUSIC_COVER_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/music_generation",
+    "cn_zh": "https://api.minimaxi.com/v1/music_generation",
+}
+MINIMAX_MUSIC_COVER_MODELS = ("music-cover", "music-cover-free")
+MINIMAX_MUSIC_COVER_OUTPUT_FORMATS = ("url", "hex")
+
+
+def _request_music_cover(endpoint, api_key, payload):
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response:
+            response_body = response.read()
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"MiniMax music cover request failed with HTTP {exc.code}."
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError("MiniMax music cover request failed.") from exc
+
+    try:
+        response_json = json.loads(response_body)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("MiniMax music cover returned invalid JSON.") from exc
+
+    base_response = response_json.get("base_resp") or {}
+    if base_response.get("status_code") != 0:
+        message = base_response.get("status_msg") or "unknown API error"
+        raise RuntimeError(f"MiniMax music cover request failed: {message}")
+
+    data = response_json.get("data") or {}
+    if data.get("status") not in (None, 2, "2"):
+        raise RuntimeError("MiniMax music cover did not return completed audio.")
+
+    audio = data.get("audio")
+    if not isinstance(audio, str) or not audio:
+        raise RuntimeError("MiniMax music cover response did not include audio.")
+    return audio
+
+
+def _audio_bytes_from_response(audio):
+    if not isinstance(audio, str) or not audio:
+        raise ValueError("MiniMax music cover returned an empty audio value.")
+
+    if audio.startswith(("http://", "https://")):
+        try:
+            with urllib.request.urlopen(audio, timeout=300) as response:
+                return response.read()
+        except (urllib.error.HTTPError, urllib.error.URLError) as exc:
+            raise RuntimeError("MiniMax music cover audio download failed.") from exc
+
+    try:
+        return bytes.fromhex(audio)
+    except ValueError as exc:
+        raise ValueError("MiniMax music cover audio was neither a URL nor hex.") from exc
+
+
+class MiniMax_MusicCover:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "api_key": ("STRING", {"default": "", "multiline": False}),
+                "model": (
+                    list(MINIMAX_MUSIC_COVER_MODELS),
+                    {"default": "music-cover"},
+                ),
+                "region": (
+                    list(MINIMAX_MUSIC_COVER_ENDPOINTS),
+                    {"default": "global_en"},
+                ),
+                "audio_url": ("STRING", {"default": "", "multiline": False}),
+                "audio_base64": (
+                    "STRING",
+                    {"default": "", "multiline": True},
+                ),
+                "cover_feature_id": (
+                    "STRING",
+                    {"default": "", "multiline": False},
+                ),
+                "output_format": (
+                    list(MINIMAX_MUSIC_COVER_OUTPUT_FORMATS),
+                    {"default": "url"},
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("AUDIO", "STRING")
+    RETURN_NAMES = ("audio_output", "filepath")
+    FUNCTION = "generate"
+    CATEGORY = "HeartMuLa"
+
+    def generate(
+        self,
+        api_key,
+        model,
+        region,
+        audio_url,
+        audio_base64,
+        cover_feature_id,
+        output_format,
+    ):
+        api_key = (api_key or "").strip()
+        audio_url = (audio_url or "").strip()
+        audio_base64 = "".join((audio_base64 or "").split())
+        cover_feature_id = (cover_feature_id or "").strip()
+
+        if not api_key:
+            raise ValueError("MiniMax API key is required.")
+        if model not in MINIMAX_MUSIC_COVER_MODELS:
+            raise ValueError(f"Unsupported MiniMax music cover model: {model}")
+        if region not in MINIMAX_MUSIC_COVER_ENDPOINTS:
+            raise ValueError(f"Unsupported MiniMax region: {region}")
+        if output_format not in MINIMAX_MUSIC_COVER_OUTPUT_FORMATS:
+            raise ValueError(f"Unsupported MiniMax output format: {output_format}")
+        if not cover_feature_id:
+            raise ValueError("MiniMax cover feature ID is required.")
+        if bool(audio_url) == bool(audio_base64):
+            raise ValueError("Provide exactly one of audio_url or audio_base64.")
+
+        payload = {
+            "model": model,
+            "cover_feature_id": cover_feature_id,
+            "output_format": output_format,
+            "audio_setting": {"format": "mp3"},
+        }
+        if audio_url:
+            payload["audio_url"] = audio_url
+        else:
+            payload["audio_base64"] = audio_base64
+
+        audio = _request_music_cover(
+            MINIMAX_MUSIC_COVER_ENDPOINTS[region], api_key, payload
+        )
+        audio_bytes = _audio_bytes_from_response(audio)
+
+        import folder_paths
+        import torch
+        import torchaudio
+
+        output_dir = folder_paths.get_output_directory()
+        os.makedirs(output_dir, exist_ok=True)
+        output_path = os.path.join(
+            output_dir, f"minimax_music_cover_{uuid.uuid4().hex}.mp3"
+        )
+        with open(output_path, "wb") as output_file:
+            output_file.write(audio_bytes)
+
+        waveform, sample_rate = torchaudio.load(output_path)
+        if waveform.ndim == 1:
+            waveform = waveform.unsqueeze(0)
+        if waveform.dtype != torch.float32:
+            waveform = waveform.float()
+        if waveform.ndim == 2:
+            waveform = waveform.unsqueeze(0)
+
+        return ({"waveform": waveform, "sample_rate": sample_rate}, output_path)

--- a/tests/test_minimax_music_cover.py
+++ b/tests/test_minimax_music_cover.py
@@ -1,0 +1,106 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+
+from minimax_music_cover import (  # noqa: E402
+    MiniMax_MusicCover,
+    _audio_bytes_from_response,
+    _request_music_cover,
+)
+
+
+class _Response:
+    def __init__(self, body):
+        self.body = body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class MiniMaxMusicCoverTests(unittest.TestCase):
+    def test_request_uses_bearer_auth_and_cover_fields(self):
+        response = _Response(
+            json.dumps(
+                {
+                    "base_resp": {"status_code": 0},
+                    "data": {"status": 2, "audio": "00ff"},
+                }
+            ).encode()
+        )
+        payload = {
+            "model": "music-cover",
+            "audio_base64": "ZmFrZQ==",
+            "cover_feature_id": "feature-id",
+        }
+
+        with patch(
+            "minimax_music_cover.urllib.request.urlopen", return_value=response
+        ) as open_url:
+            self.assertEqual(
+                _request_music_cover(
+                    "https://api.minimax.io/v1/music_generation",
+                    "test-key",
+                    payload,
+                ),
+                "00ff",
+            )
+
+        request = open_url.call_args.args[0]
+        self.assertEqual(request.get_header("Authorization"), "Bearer test-key")
+        self.assertEqual(json.loads(request.data), payload)
+
+    def test_url_audio_is_downloaded(self):
+        with patch(
+            "minimax_music_cover.urllib.request.urlopen",
+            return_value=_Response(b"audio-bytes"),
+        ) as open_url:
+            self.assertEqual(
+                _audio_bytes_from_response("https://cdn.example/audio.mp3"),
+                b"audio-bytes",
+            )
+        self.assertEqual(open_url.call_args.args[0], "https://cdn.example/audio.mp3")
+
+    def test_hex_audio_is_decoded(self):
+        self.assertEqual(_audio_bytes_from_response("00 ff 10"), b"\x00\xff\x10")
+
+    def test_node_exposes_cover_models_and_sources(self):
+        required = MiniMax_MusicCover.INPUT_TYPES()["required"]
+        self.assertEqual(required["model"][0], ["music-cover", "music-cover-free"])
+        self.assertIn("audio_url", required)
+        self.assertIn("audio_base64", required)
+        self.assertIn("cover_feature_id", required)
+
+    def test_node_requires_exactly_one_audio_source(self):
+        node = MiniMax_MusicCover()
+        common_args = (
+            "test-key",
+            "music-cover",
+            "global_en",
+        )
+
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            node.generate(*common_args, "", "", "feature-id", "url")
+
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            node.generate(
+                *common_args,
+                "https://cdn.example/input.mp3",
+                "ZmFrZQ==",
+                "feature-id",
+                "url",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reason: Add a MiniMax music-cover node for reference-audio workflows in ComfyUI.

- Add global and CN endpoint selection with Bearer authentication.
- Support `music-cover` and `music-cover-free` using exactly one of `audio_url` or `audio_base64` plus `cover_feature_id`.
- Decode URL or hex audio responses into ComfyUI `AUDIO` output.
- Register the node and add focused request and response tests.

Checks:
- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile __init__.py minimax_music_cover.py tests/test_minimax_music_cover.py`
- `git -c core.whitespace=cr-at-eol diff origin/main...HEAD --check`
